### PR TITLE
Split duration rendering into human_duration_string utility function

### DIFF
--- a/natural_duration/fields.py
+++ b/natural_duration/fields.py
@@ -8,6 +8,9 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.dateparse import parse_duration
 from django.utils.duration import duration_string
 
+from .utils import human_duration_string
+
+
 MICRO = timedelta(microseconds=1)
 MILLIS = timedelta(milliseconds=1)
 SECOND = timedelta(seconds=1)
@@ -145,32 +148,5 @@ class NaturalDurationField(Field):
             return duration_string(value)
         elif value == timedelta():
             return "a moment"
-        builder = []
-        # a list of tuples like ngettext (but with no subs for single)
-
-        us = abs(value.microseconds)
-        seconds = abs(value.seconds)
-        days = abs(value.days)
-        builder.append(('a year', '%d years', days // 365))
-        builder.append(('a month', '%d months', days % 365 // 30))
-        builder.append(('a week', '%d weeks', days % 365 % 30 // 7))
-        builder.append(('a day', '%d days', days % 365 % 30 % 7))
-        builder.append(('an hour', '%d hours', seconds // 60 // 60))
-        builder.append(('a minute', '%d minutes', seconds // 60 % 60))
-        builder.append(('a second', '%d seconds', seconds % 60))
-        builder.append(('a millisecond', '%d milliseconds', us // 1000))
-        builder.append(('a microsecond', '%d microseconds', us % 1000))
-
-        legit = []
-        for tup in builder:
-            if tup[2] == 0:
-                continue
-            elif tup[2] == 1:
-                legit.append(tup[0])
-            else:
-                legit.append(tup[1] % tup[2])
-        if len(legit) == 1:
-            return legit[0]
-        elif len(legit) == 2:
-            return legit[0] + " and " + legit[1]
-        return ", ".join(legit[:-1]) + ", and " + legit[-1]
+        else:
+            return human_duration_string(value)

--- a/natural_duration/utils.py
+++ b/natural_duration/utils.py
@@ -1,0 +1,30 @@
+def human_duration_string(value):
+    builder = []
+    # a list of tuples like ngettext (but with no subs for single)
+
+    us = abs(value.microseconds)
+    seconds = abs(value.seconds)
+    days = abs(value.days)
+    builder.append(('a year', '%d years', days // 365))
+    builder.append(('a month', '%d months', days % 365 // 30))
+    builder.append(('a week', '%d weeks', days % 365 % 30 // 7))
+    builder.append(('a day', '%d days', days % 365 % 30 % 7))
+    builder.append(('an hour', '%d hours', seconds // 60 // 60))
+    builder.append(('a minute', '%d minutes', seconds // 60 % 60))
+    builder.append(('a second', '%d seconds', seconds % 60))
+    builder.append(('a millisecond', '%d milliseconds', us // 1000))
+    builder.append(('a microsecond', '%d microseconds', us % 1000))
+
+    legit = []
+    for tup in builder:
+        if tup[2] == 0:
+            continue
+        elif tup[2] == 1:
+            legit.append(tup[0])
+        else:
+            legit.append(tup[1] % tup[2])
+    if len(legit) == 1:
+        return legit[0]
+    elif len(legit) == 2:
+        return legit[0] + " and " + legit[1]
+    return ", ".join(legit[:-1]) + ", and " + legit[-1]


### PR DESCRIPTION
This does not change anything behaviour-wise, it just splits the rendering of durations into a utility function as a project where we're using NaturalDurationField in a form now needs to render durations in exactly the same way as they're accepted.  